### PR TITLE
refactor: introduce dprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  code_quality:
+    name: Code quality
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - uses: taiki-e/install-action@dprint
+
+      - name: Show version information
+        shell: bash
+        run: |
+          dprint --version
+
+      - name: Ensure `fmt` has been run
+        run:  dprint check
+
+
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: zola
+
+      - name: Show version information
+        shell: bash
+        run: |
+          zola --version
+
+      - name: Build
+        run: zola build

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ the Hayden at his personal email address
 
 [coc]: https://github.com/rust-lang/rust/blob/master/CODE_OF_CONDUCT.md
 
-
 ## Disclaimer
 
 Rust for Lunch is not associated with or endorsed by either the

--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,6 @@ build_search_index = false
 generate_feed = true
 feed_filename = "rss.xml"
 
-
 [markdown]
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola

--- a/content/_index.md
+++ b/content/_index.md
@@ -10,5 +10,3 @@ slot and the time is chosen to be a feasible lunch time.
 
 The first meet-up will be scheduled around European and African midday and
 early afternoon.
-
-

--- a/content/about.md
+++ b/content/about.md
@@ -42,5 +42,4 @@ open an issue on the
 ## Contact
 
 You can get in touch with Hayden at his
-[personal email address](mailto:hds@hegdenu.net). See the [hegdenu.net about
-page](https://hegdenu.net/about/#contact) for more ways.
+[personal email address](mailto:hds@hegdenu.net). See the [hegdenu.net about page](https://hegdenu.net/about/#contact) for more ways.

--- a/content/meetups/2023-10-31.md
+++ b/content/meetups/2023-10-31.md
@@ -11,12 +11,12 @@ We'd like to remind everyone that all participants (speakers, moderators, and
 attendees) must follow the [Code of Conduct](@/about.md#code-of-conduct) during
 the meetup.
 
-* Meet-up call link: *coming soon*
-* Date: **Tuesday, 31 October, 2023**
-* Time: [**12:00 - 13:00 UTC**](https://everytimezone.com/s/0638f484)
-  * **12:00 - 13:00 GMT** (e.g. London, Bamako)
-  * **13:00 - 14:00 WAT/CET** (e.g. Kinshasa, Berlin)
-  * **14:00 - 15:00 EET/CAT** (e.g. Lviv, Cairo)
+- Meet-up call link: _coming soon_
+- Date: **Tuesday, 31 October, 2023**
+- Time: [**12:00 - 13:00 UTC**](https://everytimezone.com/s/0638f484)
+  - **12:00 - 13:00 GMT** (e.g. London, Bamako)
+  - **13:00 - 14:00 WAT/CET** (e.g. Kinshasa, Berlin)
+  - **14:00 - 15:00 EET/CAT** (e.g. Lviv, Cairo)
 
 ### Talk: Abusing the Type System for Fun and for Profit
 

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,11 @@
+{
+  "markdown": {
+  },
+  "toml": {
+  },
+  "excludes": [],
+  "plugins": [
+    "https://plugins.dprint.dev/markdown-0.16.2.wasm",
+    "https://plugins.dprint.dev/toml-0.5.4.wasm"
+  ]
+}


### PR DESCRIPTION
dprint allows for consistent content formatting.
It is currently used to format markdown and toml files in this repo.