### PR TITLE
meetup: add call link

### DIFF
--- a/content/meetups/2023-11-28.md
+++ b/content/meetups/2023-11-28.md
@@ -12,7 +12,7 @@ We'd like to remind everyone that all participants (speakers, moderators, and
 attendees) must follow the [Code of Conduct](@/about.md#code-of-conduct) during
 the meetup.
 
-- Meet-up call link: _coming soon_
+- Meet-up call link: [https://lecture.senfcall.de/hay-gmh-wox-mru](https://lecture.senfcall.de/hay-gmh-wox-mru) (Senfcall)
 - Date: **Tuesday, 28 November, 2023**
 - Time: [**12:00 - 13:00 UTC**](https://everytimezone.com/s/e35f56e0)
   - **12:00 - 13:00 GMT** (e.g. London, Bamako)


### PR DESCRIPTION
It's the same as the previous meet-up, as it's a Senfcall room.