### PR TITLE
meetup: remove second talk

### DIFF
--- a/content/meetups/2023-11-28.md
+++ b/content/meetups/2023-11-28.md
@@ -30,6 +30,5 @@ different can of worms (Spoiler: it's counting instructions, we'll have to
 count instructions, but we'll have to do it somewhat efficiently, and we'll do
 it by analyzing and modifying the original code).
 
-### Talk 2: Adventures in Fearless Parallelism
-
-#### Speaker: Christian Vetter
+**Unfortunatebly the second talk for this meet-up has been cancelled. Instead,
+the first talk will run a bit longer.**


### PR DESCRIPTION
The second talk by Christian had to be cancelled, so there will just be
a single talk at this Rust for Lunch.