### PR TITLE
chore: update config values for latest version of Zola

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,8 +7,8 @@ compile_sass = false
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = false
 
-generate_feed = true
-feed_filename = "rss.xml"
+generate_feeds = true
+feed_filenames = ["rss.xml"]
 
 [markdown]
 # Whether to do syntax highlighting


### PR DESCRIPTION
We needed to change `generate_feed` to to `generate_feeds` and
`feed_filename` to `feed_filenames`. Additionally, `feed_filenames` now
takes a sequence instead of a string.