### PR TITLE
meetup: Switch to backup plan for September meetup-2024-09-17-backup

### DIFF
--- a/content/meetups/2024-10-14.md
+++ b/content/meetups/2024-10-14.md
@@ -4,8 +4,8 @@ date = "2024-09-17"
 draft = false
 +++
 
-Welcome back! After our summer break, the September 2024 Rust for Lunch meet-up will be a group
-implementation session!
+Welcome back! After our summer break, the September 2024 Rust for Lunch meet-up will have a single
+talk with time for questions afterwards.
 
 We'd like to remind everyone that all participants (speakers, moderators, and attendees) must follow
 the [Code of Conduct](@/about.md#code-of-conduct) during the meetup.
@@ -17,12 +17,15 @@ the [Code of Conduct](@/about.md#code-of-conduct) during the meetup.
   - **13:00 - 14:00 WAT/CET** (e.g. Kinshasa, Berlin)
   - **14:00 - 15:00 EET/CAT** (e.g. Lviv, Cairo)
 
-### Let's write an HTTP server in Rust
+### Getting started with embedded Rust
 
-#### Speaker: [Hayden Stainsby](https://hegdenu.net/)
+#### Speaker: [Sandro Stikić](https://stikić.com/)
 
-Bring your copy of [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616), we're going to write
-an HTTP server!
-
-This will be a group implementation session, where we'll do our best to get a `curl`-compliant HTTP
-server responding with something simple by the end of our lunch break.
+- learn how to get started with embedded rust development! my thesis statement is: "embedded
+  development should be fun!"
+- i plan to detail the entire process of flashing a hello world program onto a microcontroller using
+  a pure rust stack
+- what hardware is required/recommended
+- recommended rust crates
+- connecting up the hardware
+- how to write and flash the software


### PR DESCRIPTION
Due to illness, the planned talk for September will happen in our next
meet-up in October. We'll go with a backup plan instead.